### PR TITLE
enhancement - chrome - consider synchronizing user data across computers

### DIFF
--- a/src/background/db.js
+++ b/src/background/db.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 
 import { isEmpty, isFunction } from '../utils';
 
-const backend = chrome.storage.local;
+const backend = chrome.storage.sync;
 
 function get (key, setIfMissing) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
for users accessing facebook from multiple computers (like myself), it's a little annoying having to post the pairing message on your fb wall multiple times, one for each computer.

Since the extension is already being automagically sync'ed by Chrome across computers, it'd be nice to sync user data as well.

According to [this dev page][1], it looks like all that's needed is the little change I made here, as long as the user is using a single fb account, that is. Please **note**: I haven't tested it.

[1]: https://developer.chrome.com/extensions/storage