### PR TITLE
Update collector URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Nothing yet.
 
 ### Changed
-- Nothing yey.
+- API endpoint is now `https://collector.facebook.tracking.exposed/`
 
 ### Fixed
 - Nothing yet.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ const PATHS = {
 const DEFINITIONS = {
     'process.env': {
         NODE_ENV: JSON.stringify(NODE_ENV),
-        API_ROOT: JSON.stringify((DEVELOPMENT ? 'http://localhost:8000/' : 'https://facebook.tracking.exposed/') + 'api/v' + LAST_VERSION + '/'),
+        API_ROOT: JSON.stringify((DEVELOPMENT ? 'http://localhost:8000/' : 'https://collector.facebook.tracking.exposed/') + 'api/v' + LAST_VERSION + '/'),
         VERSION: JSON.stringify(packageJSON.version + (DEVELOPMENT ? '-dev' : '')),
         BUILD: JSON.stringify(BUILD),
         FLUSH_INTERVAL: JSON.stringify(DEVELOPMENT ? 10000 : 20000)


### PR DESCRIPTION
API endpoint is now `https://collector.facebook.tracking.exposed/`.