### PR TITLE
Fix possibly wrong publicWords translation for Belgian

### DIFF
--- a/src/scrape.js
+++ b/src/scrape.js
@@ -16,7 +16,7 @@ var publicWords = [
     'tutti',        // Italiano
     'público',      // Português
     'openbaar',     // 'Nederlands',
-    'ledereen'      // 'Nederlands (België)'
+    'iedereen'      // 'Nederlands (België)'
 ];
 
 export function scrape (elem) {


### PR DESCRIPTION
While browsing the code, I noticed that the [`publicWords` translation for Belgian](https://github.com/tracking-exposed/web-extension/blob/dc5505ae896780a240410e6c4c87188d468ccfa7/src/scrape.js#L19) is `ledereen`, which uses a lowercase `L` as first letter, while probably a lowercase `i` is intended.

I haven't tested this change, nor do I definitively know how this is displayed in the Facebook interface. However, `ledereen` is not a Dutch word, while `iedereen` means "everyone".