### PR TITLE
Generate manifest.json from package.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,8 +4,8 @@
   "name": "__MSG_extensionName__",
   "short_name": "FbTREX",
   "description": "__MSG_extensionDescription__",
-  "version": "2.0.0",
-  "version_name": "2.0.0-rc.2",
+  "version": "<managed by rollup>",
+  "version_name": "<managed by rollup>",
   "author": "Alberto Granzotto, Claudio Agosti, and the contributors in https://github.com/tracking-exposed/web-extension",
 
   "default_locale": "en",


### PR DESCRIPTION
So we don't need to manually update the version number (it's taken from `package.json`) and manually remove `localhost` when building for production.