### PR TITLE
Fix network error on redirect

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,6 +23,7 @@
     "cookies",
     "http://localhost:8100/",
     "https://*.facebook.com/",
+    "https://*.fbcdn.net/",
     "https://*.tracking.exposed/"
   ],
 


### PR DESCRIPTION
The profile picture of the user was served from a different domain. Had to add `https://*.fbcdn.net/"` to the allowed domains.

I guess that was the original reason why loading the profile picture from the popup was failing in some browsers. We have some extra logic to save the profile picture in local storage, but I think it's fine.