### PR TITLE
Fix avatar retrieval

### DIFF
--- a/src/domains/facebook.com/content_scripts/index.js
+++ b/src/domains/facebook.com/content_scripts/index.js
@@ -23,6 +23,10 @@ async function boot() {
     method: "loadProfile"
   });
 
+  if (profile) {
+    retrievePicture(profile.id);
+  }
+
   console.info("Profile loaded", profile);
 
   const hub = new Hub();
@@ -32,7 +36,6 @@ async function boot() {
   hub.send("updateConfig", profile);
 
   if (profile && !profile.optIn) {
-    retrievePicture(profile.id);
     new Onboarding({ target: document.body, props: { hub } });
   }
 


### PR DESCRIPTION
Avatar was retrieved only during onboarding, making it unavailable to users that migrated from version 1 to version 2.